### PR TITLE
Clean up announcements and taxi modules

### DIFF
--- a/HydraUI/Elements/Announcements.lua
+++ b/HydraUI/Elements/Announcements.lua
@@ -21,8 +21,6 @@ local MyGUID = UnitGUID("player")
 local PetGUID = ""
 local _
 
-local Channel
-
 Defaults["announcements-enable"] = true
 Defaults["announcements-channel"] = "SELF"
 
@@ -30,56 +28,56 @@ Announcements.Spells = {
 
 }
 
+local Announce = function(message)
+        local Channel = Announcements:GetChannelToSend()
+
+        if Channel then
+                SendChatMessage(message, Channel)
+        else
+                print(message)
+        end
+end
+
 function Announcements:GetChannelToSend()
-	if ((Settings["announcements-channel"] == "SELF") or (IsBattleground() or IsRatedBattleground())) then
-		return
-	elseif (Settings["announcements-channel"] == "GROUP") then
-		if IsInGroup(LE_PARTY_CATEGORY_INSTANCE) then
-			return "INSTANCE_CHAT"
-		elseif IsInGroup(LE_PARTY_CATEGORY_HOME) then
+        local Setting = Settings["announcements-channel"]
+
+        if ((Setting == "SELF") or (IsBattleground() or IsRatedBattleground())) then
+                return
+        elseif (Setting == "GROUP") then
+                if IsInGroup(LE_PARTY_CATEGORY_INSTANCE) then
+                        return "INSTANCE_CHAT"
+                elseif IsInGroup(LE_PARTY_CATEGORY_HOME) then
 			if IsInRaid() then
 				return "RAID"
 			else
 				return "PARTY"
 			end
 		end
-	elseif (Settings["announcements-channel"] == "SAY") then
-		return "SAY"
-	else
-		return "EMOTE"
-	end
+        elseif (Setting == "SAY") then
+                return "SAY"
+        else
+                return "EMOTE"
+        end
 end
 
 Announcements.Events = {
-	["SPELL_INTERRUPT"] = function(target, id, spell)
-		if UnitIsFriend("player", target) then -- Quaking filter
-			return
-		end
+        ["SPELL_INTERRUPT"] = function(target, id, spell)
+                if UnitIsFriend("player", target) then -- Quaking filter
+                        return
+                end
 
-		Channel = Announcements:GetChannelToSend()
+                Announce(format(InterruptMessage, target, id, spell))
+        end,
 
-		if Channel then
-			SendChatMessage(format(InterruptMessage, target, id, spell), Channel)
-		else
-			print(format(InterruptMessage, target, id, spell))
-		end
-	end,
+        --[[["SPELL_DISPEL"] = function(target, id, spell)
+                if (not UnitIsFriend("player", target)) then
+                        SendChatMessage(format(DispelledMessage, target, id, spell), "EMOTE")
+                end
+        end,]]
 
-	--[[["SPELL_DISPEL"] = function(target, id, spell)
-		if (not UnitIsFriend("player", target)) then
-			SendChatMessage(format(DispelledMessage, target, id, spell), "EMOTE")
-		end
-	end,]]
-
-	["SPELL_STOLEN"] = function(target, id, spell)
-		Channel = Announcements:GetChannelToSend()
-
-		if Channel then
-			SendChatMessage(format(StolenMessage, target, id, spell), Channel)
-		else
-			print(format(StolenMessage, target, id, spell))
-		end
-	end,
+        ["SPELL_STOLEN"] = function(target, id, spell)
+                Announce(format(StolenMessage, target, id, spell))
+        end,
 }
 
 function Announcements:COMBAT_LOG_EVENT_UNFILTERED()
@@ -115,8 +113,10 @@ function Announcements:UNIT_PET(owner)
 	end
 end
 
-function Announcements:OnEvent(event, arg)
-	self[event](self, arg)
+function Announcements:OnEvent(event, ...)
+        if self[event] then
+                self[event](self, ...)
+        end
 end
 
 function Announcements:Load()
@@ -127,9 +127,9 @@ function Announcements:Load()
 	self:GROUP_ROSTER_UPDATE()
 	self:UNIT_PET("player")
 
-	self:RegisterEvent("UNIT_PET")
-	self:RegisterEvent("GROUP_ROSTER_UPDATE")
-	self:SetScript("OnEvent", self.OnEvent)
+        self:RegisterEvent("UNIT_PET")
+        self:RegisterEvent("GROUP_ROSTER_UPDATE")
+        self:SetScript("OnEvent", self.OnEvent)
 end
 
 HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["General"], function(left, right)

--- a/HydraUI/Elements/Taxi.lua
+++ b/HydraUI/Elements/Taxi.lua
@@ -1,32 +1,39 @@
 local HydraUI, Language, Assets, Settings = select(2, ...):get()
 
 local Taxi = HydraUI:NewModule("Vehicle")
+local GameTooltip = GameTooltip
+local UnitOnTaxi = UnitOnTaxi
+local TaxiRequestEarlyLanding = TaxiRequestEarlyLanding
 
 function Taxi:OnEnter()
-	local R, G, B = HydraUI:HexToRGB(Settings["ui-widget-font-color"])
+        local R, G, B = HydraUI:HexToRGB(Settings["ui-widget-font-color"])
 
-	GameTooltip:SetOwner(self, "ANCHOR_BOTTOMRIGHT", 0, -6)
-	GameTooltip:AddLine(TAXI_CANCEL_DESCRIPTION, R, G, B)
-	GameTooltip:Show()
+        GameTooltip:SetOwner(self, "ANCHOR_BOTTOMRIGHT", 0, -6)
+        GameTooltip:AddLine(TAXI_CANCEL_DESCRIPTION, R, G, B)
+        GameTooltip:Show()
 end
 
 function Taxi:OnLeave()
-	GameTooltip:Hide()
+        GameTooltip:Hide()
 end
 
 function Taxi:OnMouseUp()
-    if UnitOnTaxi("player") then
-        TaxiRequestEarlyLanding()
-		self:Hide()
-    end
+        if UnitOnTaxi("player") then
+                TaxiRequestEarlyLanding()
+                self:Hide()
+        end
+end
+
+function Taxi:UpdateVisibility()
+        if UnitOnTaxi("player") then
+                self:Show()
+        else
+                self:Hide()
+        end
 end
 
 function Taxi:OnEvent()
-    if UnitOnTaxi("player") then
-        self:Show()
-    else
-		self:Hide()
-    end
+        self:UpdateVisibility()
 end
 
 function Taxi:Load()
@@ -35,21 +42,17 @@ function Taxi:Load()
 	self:SetBackdropColor(HydraUI:HexToRGB(Settings["ui-window-bg-color"]))
 	self:SetBackdropBorderColor(0, 0, 0)
 	self:SetFrameStrata("HIGH")
-	self:SetFrameLevel(10)
-	self:RegisterEvent("UPDATE_BONUS_ACTIONBAR")
-	self:SetScript("OnMouseUp", self.OnMouseUp)
-	self:SetScript("OnEnter", self.OnEnter)
-	self:SetScript("OnLeave", self.OnLeave)
-	self:SetScript("OnEvent", self.OnEvent)
+        self:SetFrameLevel(10)
+        self:RegisterEvent("UPDATE_BONUS_ACTIONBAR")
+        self:SetScript("OnMouseUp", self.OnMouseUp)
+        self:SetScript("OnEnter", self.OnEnter)
+        self:SetScript("OnLeave", self.OnLeave)
+        self:SetScript("OnEvent", self.OnEvent)
 
-    if UnitOnTaxi("player") then
-        self:Show()
-    else
-		self:Hide()
-    end
+        self:UpdateVisibility()
 
-	self.Texture = self:CreateTexture(nil, "ARTWORK")
-	self.Texture:SetPoint("TOPLEFT", self, 1, -1)
+        self.Texture = self:CreateTexture(nil, "ARTWORK")
+        self.Texture:SetPoint("TOPLEFT", self, 1, -1)
 	self.Texture:SetPoint("BOTTOMRIGHT", self, -1, 1)
 	self.Texture:SetTexture(Assets:GetTexture(Settings["ui-header-texture"]))
 	self.Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-header-texture-color"]))


### PR DESCRIPTION
## Summary
- centralize announcement dispatch to avoid repeated channel lookups
- make the announcements event handler handle arbitrary arguments safely
- refactor the taxi module to reuse shared visibility logic and cache globals

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5c9a42274832f9cc73dd854fd892e