### PR TITLE
Optimize update messaging queue and system datatext

### DIFF
--- a/HydraUI/Elements/DataTexts/System.lua
+++ b/HydraUI/Elements/DataTexts/System.lua
@@ -3,18 +3,18 @@ local HydraUI, Language, Assets, Settings = select(2, ...):get()
 local GetFramerate = GetFramerate
 local GetNetStats = GetNetStats
 local floor = floor
-local select = select
+local format = format
 local FPSLabel = Language["FPS"]
 local MSLabel = Language["MS"]
 
 local OnEnter = function(self)
 	self:SetTooltip()
 
-	local HomeLatency, WorldLatency = select(3, GetNetStats())
+        local _, _, HomeLatency, WorldLatency = GetNetStats()
 
-	GameTooltip:AddLine(Language["Latency:"], 1, 0.7, 0)
-	GameTooltip:AddLine(format(Language["%s ms (home)"], HomeLatency), 1, 1, 1)
-	GameTooltip:AddLine(format(Language["%s ms (world)"], WorldLatency), 1, 1, 1)
+        GameTooltip:AddLine(Language["Latency:"], 1, 0.7, 0)
+        GameTooltip:AddLine(format(Language["%s ms (home)"], HomeLatency), 1, 1, 1)
+        GameTooltip:AddLine(format(Language["%s ms (world)"], WorldLatency), 1, 1, 1)
 
 	GameTooltip:Show()
 end
@@ -26,31 +26,43 @@ end
 local Update = function(self, elapsed)
 	self.Elapsed = self.Elapsed + elapsed
 
-	if (self.Elapsed > 1) then
-		self.Text:SetFormattedText("|cFF%s%s:|r |cFF%s%s|r |cFF%s%s:|r |cFF%s%s|r", Settings["data-text-label-color"], FPSLabel, HydraUI.ValueColor, floor(GetFramerate()), Settings["data-text-label-color"], MSLabel, HydraUI.ValueColor, select(4, GetNetStats()))
+        if (self.Elapsed > 1) then
+                local fps = floor(GetFramerate())
+                local _, _, _, worldLatency = GetNetStats()
 
-		self.Elapsed = 0
-	end
+                if (fps ~= self.LastFPS) or (worldLatency ~= self.LastLatency) then
+                        self.LastFPS = fps
+                        self.LastLatency = worldLatency
+
+                        self.Text:SetFormattedText("|cFF%s%s:|r |cFF%s%s|r |cFF%s%s:|r |cFF%s%s|r", Settings["data-text-label-color"], FPSLabel, HydraUI.ValueColor, fps, Settings["data-text-label-color"], MSLabel, HydraUI.ValueColor, worldLatency)
+                end
+
+                self.Elapsed = 0
+        end
 end
 
 local OnEnable = function(self)
-	self:SetScript("OnUpdate", Update)
-	self:SetScript("OnEnter", OnEnter)
-	self:SetScript("OnLeave", OnLeave)
+        self:SetScript("OnUpdate", Update)
+        self:SetScript("OnEnter", OnEnter)
+        self:SetScript("OnLeave", OnLeave)
 
-	self.Elapsed = 0
+        self.Elapsed = 0
+        self.LastFPS = nil
+        self.LastLatency = nil
 
-	self:Update(2)
+        self:Update(2)
 end
 
 local OnDisable = function(self)
-	self:SetScript("OnUpdate", nil)
-	self:SetScript("OnEnter", nil)
-	self:SetScript("OnLeave", nil)
+        self:SetScript("OnUpdate", nil)
+        self:SetScript("OnEnter", nil)
+        self:SetScript("OnLeave", nil)
 
-	self.Elapsed = 0
+        self.Elapsed = 0
+        self.LastFPS = nil
+        self.LastLatency = nil
 
-	self.Text:SetText("")
+        self.Text:SetText("")
 end
 
 HydraUI:AddDataText("System", OnEnable, OnDisable, Update)


### PR DESCRIPTION
## Summary
- deduplicate queued addon version broadcasts and fully recycle pooled table state when dispatching
- guard group roster announcements on queue success to avoid suppressing later sends
- cache the most recent FPS/latency values in the System data text to reduce redundant formatting and API calls

## Testing
- not run (WoW environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5d2b49324832fa22e758cc7d24cbe