### PR TITLE
Enhance throttle helper with callbacks and utility optimizations

### DIFF
--- a/HydraUI/Elements/Tools.lua
+++ b/HydraUI/Elements/Tools.lua
@@ -6,7 +6,9 @@ local select = select
 local date = date
 local sub = string.sub
 local format = string.format
+local gsub = string.gsub
 local floor = math.floor
+local ceil = math.ceil
 local match = string.match
 local reverse = string.reverse
 


### PR DESCRIPTION
## Summary
- add expiration handling to the throttle module with helpers to cancel, query, and run throttled work
- cache frequently used math and string helpers to reduce repeated global lookups in the tools module

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d60ddff88c832faf8659e672d12999