### PR TITLE
Optimize color conversions and caching

### DIFF
--- a/HydraUI/Elements/Colors.lua
+++ b/HydraUI/Elements/Colors.lua
@@ -117,16 +117,33 @@ HydraUI.ComboPoints = {}
 HydraUI.TotemColors = {}
 
 function HydraUI:SetColorEntry(t, key, hex)
-	R, G, B = self:HexToRGB(hex)
+        if (not hex) then
+                return
+        end
 
-	if (not t[key]) then
-		t[key] = {}
-	end
+        local normalized = self:NormalizeHex(hex)
 
-	t[key][1] = R
-	t[key][2] = G
-	t[key][3] = B
-	t[key]["Hex"] = hex
+        if (not normalized) then
+                return
+        end
+
+        local entry = t[key]
+
+        if (entry and entry.Hex == normalized) then
+                return
+        end
+
+        R, G, B = self:HexToRGB(normalized)
+
+        if (not entry) then
+                entry = {}
+                t[key] = entry
+        end
+
+        entry[1] = R
+        entry[2] = G
+        entry[3] = B
+        entry.Hex = normalized
 end
 
 function HydraUI:UpdateClassColors()

--- a/HydraUI/Elements/Tools.lua
+++ b/HydraUI/Elements/Tools.lua
@@ -11,18 +11,74 @@ local floor = math.floor
 local ceil = math.ceil
 local match = string.match
 local reverse = string.reverse
+local upper = string.upper
+local min = math.min
+local max = math.max
+
+HydraUI.HexToRGBCache = HydraUI.HexToRGBCache or {}
+
+local HexCache = HydraUI.HexToRGBCache
+
+local GetOrCreateRGB = function(hex)
+        local cached = HexCache[hex]
+
+        if cached then
+                return cached[1], cached[2], cached[3]
+        end
+
+        local r = tonumber(sub(hex, 1, 2), 16) / 255
+        local g = tonumber(sub(hex, 3, 4), 16) / 255
+        local b = tonumber(sub(hex, 5, 6), 16) / 255
+
+        cached = {r, g, b}
+        HexCache[hex] = cached
+
+        return r, g, b
+end
+
+function HydraUI:NormalizeHex(hex)
+        if (not hex) then
+                return
+        end
+
+        if (type(hex) ~= "string") then
+                hex = tostring(hex)
+        end
+
+        if (sub(hex, 1, 1) == "#") then
+                hex = sub(hex, 2)
+        end
+
+        hex = upper(hex)
+
+        if (#hex ~= 6) then
+                return
+        end
+
+        return hex
+end
 
 -- Tools
 function HydraUI:HexToRGB(hex)
-	if (not hex) then
-		return
-	end
+        local normalized = self:NormalizeHex(hex)
 
-	return tonumber("0x" .. sub(hex, 1, 2)) / 255, tonumber("0x" .. sub(hex, 3, 4)) / 255, tonumber("0x" .. sub(hex, 5, 6)) / 255
+        if (not normalized) then
+                return
+        end
+
+        return GetOrCreateRGB(normalized)
 end
 
 function HydraUI:RGBToHex(r, g, b)
-	return format("%02x%02x%02x", r * 255, g * 255, b * 255)
+        if (not r or not g or not b) then
+                return
+        end
+
+        r = floor(max(0, min(1, r)) * 255 + 0.5)
+        g = floor(max(0, min(1, g)) * 255 + 0.5)
+        b = floor(max(0, min(1, b)) * 255 + 0.5)
+
+        return format("%02x%02x%02x", r, g, b)
 end
 
 function HydraUI:FormatTime(seconds)


### PR DESCRIPTION
## Summary
- add normalization and caching for hex-to-RGB conversions to avoid redundant work
- clamp RGB inputs and reuse cached color tables when color settings stay the same

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6152a08b8832fb92041ea9bd9ba1b