### PR TITLE
Polish GUI scrolling and widget helpers

### DIFF
--- a/HydraUI/Elements/GUI/GUI.lua
+++ b/HydraUI/Elements/GUI/GUI.lua
@@ -24,10 +24,13 @@ local max = math.max
 local type = type
 local wipe = wipe
 local tinsert = table.insert
-local tremove = table.remove
 local tsort = table.sort
 
 local GUI = HydraUI:NewModule("GUI")
+
+local GetColorRGB = function(key)
+        return HydraUI:HexToRGB(Settings[key])
+end
 
 -- Storage
 GUI.Categories = {}
@@ -53,7 +56,7 @@ local UpdateArrows = function(scrollUp, scrollDown, offset, maxOffset)
                 return
         end
 
-        local enabledR, enabledG, enabledB = HydraUI:HexToRGB(Settings["ui-widget-color"])
+        local enabledR, enabledG, enabledB = GetColorRGB("ui-widget-color")
 
         if (offset <= 1) then
                 scrollUp.Arrow:SetVertexColor(DISABLED_SCROLL_R, DISABLED_SCROLL_G, DISABLED_SCROLL_B)
@@ -69,24 +72,33 @@ local UpdateArrows = function(scrollUp, scrollDown, offset, maxOffset)
 end
 
 local LayoutWidgetColumn = function(frame, widgets, offset, anchorPoint, anchorX)
-        local firstVisible
         local lastVisible = offset + MAX_WIDGETS_SHOWN - 1
+        local previous
 
-        for i = 1, #widgets do
+        for i = 1, offset - 1 do
+                local widget = widgets[i]
+
+                if widget then
+                        widget:Hide()
+                        widget:ClearAllPoints()
+                end
+        end
+
+        for i = offset, #widgets do
                 local widget = widgets[i]
 
                 if widget then
                         widget:ClearAllPoints()
 
-                        if (i >= offset) and (i <= lastVisible) then
-                                if not firstVisible then
+                        if (i <= lastVisible) then
+                                if not previous then
                                         widget:SetPoint(anchorPoint, frame, anchorX, -SPACING)
-                                        firstVisible = i
                                 else
-                                        widget:SetPoint("TOP", widgets[i-1], "BOTTOM", 0, -2)
+                                        widget:SetPoint("TOP", previous, "BOTTOM", 0, -2)
                                 end
 
                                 widget:Show()
+                                previous = widget
                         else
                                 widget:Hide()
                         end
@@ -121,117 +133,104 @@ end
 
 local NoScroll = function() end
 
+local SetWindowOffset = function(self, offset)
+        local newOffset = ClampOffset(self, offset)
+
+        if (self.Offset == newOffset) then
+                return false
+        end
+
+        self.Offset = newOffset
+
+        Scroll(self)
+
+        return true
+end
+
 local SetOffsetByDelta = function(self, delta)
         if (delta > 0) then -- Up
-                self.Offset = ClampOffset(self, self.Offset - 1)
+                return SetWindowOffset(self, (self.Offset or 1) - 1)
         else -- Down
-                self.Offset = ClampOffset(self, self.Offset + 1)
+                return SetWindowOffset(self, (self.Offset or 1) + 1)
         end
 end
 
 local WindowOnMouseWheel = function(self, delta)
-        SetOffsetByDelta(self, delta)
-        Scroll(self)
-        self.ScrollBar:SetValue(self.Offset)
-end
-
-local SetWindowOffset = function(self, offset)
-        self.Offset = ClampOffset(self, offset)
-
-        Scroll(self)
+        if SetOffsetByDelta(self, delta) and self.ScrollBar then
+                self.ScrollBar:SetValue(self.Offset)
+        end
 end
 
 local WindowScrollBarOnValueChanged = function(self)
-	local Parent = self:GetParent()
+        local Parent = self:GetParent()
 
-	Parent.Offset = Round(self:GetValue())
-
-	Scroll(Parent)
+        SetWindowOffset(Parent, Round(self:GetValue()))
 end
 
 local WindowScrollBarOnMouseWheel = function(self, delta)
 	WindowOnMouseWheel(self:GetParent(), delta)
 end
 
-local WindowScrollBarOnMouseUp = function(self)
-	self.Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
+local StyleScrollButton = function(button, arrowTexture, arrowR, arrowG, arrowB)
+        button:SetBackdrop(HydraUI.BackdropAndBorder)
+        button:SetBackdropColor(0, 0, 0, 0)
+        button:SetBackdropBorderColor(0, 0, 0)
 
-	WindowOnMouseWheel(self:GetParent(), 1)
+        local brightR, brightG, brightB = GetColorRGB("ui-widget-bright-color")
+
+        button.Texture = button:CreateTexture(nil, "ARTWORK")
+        button.Texture:SetPoint("TOPLEFT", button, 1, -1)
+        button.Texture:SetPoint("BOTTOMRIGHT", button, -1, 1)
+        button.Texture:SetTexture(Assets:GetTexture(Settings["ui-header-texture"]))
+        button.Texture:SetVertexColor(brightR, brightG, brightB)
+
+        button.Highlight = button:CreateTexture(nil, "HIGHLIGHT")
+        button.Highlight:SetPoint("TOPLEFT", button, 1, -1)
+        button.Highlight:SetPoint("BOTTOMRIGHT", button, -1, 1)
+        button.Highlight:SetTexture(Assets:GetTexture(Settings["ui-widget-texture"]))
+        button.Highlight:SetVertexColor(1, 1, 1)
+        button.Highlight:SetAlpha(SELECTED_HIGHLIGHT_ALPHA)
+
+        button.Arrow = button:CreateTexture(nil, "OVERLAY")
+        button.Arrow:SetPoint("CENTER", button, 0, 0)
+        button.Arrow:SetSize(16, 16)
+        button.Arrow:SetTexture(Assets:GetTexture(arrowTexture))
+
+        if arrowR then
+                button.Arrow:SetVertexColor(arrowR, arrowG, arrowB)
+        else
+                button.Arrow:SetVertexColor(GetColorRGB("ui-widget-color"))
+        end
 end
 
-local WindowScrollBarOnMouseDown = function(self)
-	local R, G, B = HydraUI:HexToRGB(Settings["ui-widget-bright-color"])
+local AttachScrollScripts = function(button, delta)
+        local brightR, brightG, brightB = GetColorRGB("ui-widget-bright-color")
 
-	self.Texture:SetVertexColor(R * 0.85, G * 0.85, B * 0.85)
+        button:SetScript("OnMouseUp", function(self)
+                self.Texture:SetVertexColor(brightR, brightG, brightB)
+
+                WindowOnMouseWheel(self:GetParent(), delta)
+        end)
+
+        button:SetScript("OnMouseDown", function(self)
+                self.Texture:SetVertexColor(brightR * 0.85, brightG * 0.85, brightB * 0.85)
+        end)
 end
 
 local AddWindowScrollBar = function(self)
-	-- Scroll up
-	self.ScrollUp = CreateFrame("Frame", nil, self, "BackdropTemplate")
-	self.ScrollUp:SetSize(16, WIDGET_HEIGHT)
-	self.ScrollUp:SetPoint("TOPRIGHT", GUI, -SPACING, -((SPACING * 2) + HEADER_HEIGHT - 1))
-	self.ScrollUp:SetBackdrop(HydraUI.BackdropAndBorder)
-	self.ScrollUp:SetBackdropColor(0, 0, 0, 0)
-	self.ScrollUp:SetBackdropBorderColor(0, 0, 0)
-	self.ScrollUp:SetScript("OnMouseUp", WindowScrollBarOnMouseUp)
-	self.ScrollUp:SetScript("OnMouseDown", WindowScrollBarOnMouseDown)
+        -- Scroll up
+        self.ScrollUp = CreateFrame("Frame", nil, self, "BackdropTemplate")
+        self.ScrollUp:SetSize(16, WIDGET_HEIGHT)
+        self.ScrollUp:SetPoint("TOPRIGHT", GUI, -SPACING, -((SPACING * 2) + HEADER_HEIGHT - 1))
+        StyleScrollButton(self.ScrollUp, "Arrow Up", DISABLED_SCROLL_R, DISABLED_SCROLL_G, DISABLED_SCROLL_B)
+        AttachScrollScripts(self.ScrollUp, 1)
 
-	self.ScrollUp.Texture = self.ScrollUp:CreateTexture(nil, "ARTWORK")
-	self.ScrollUp.Texture:SetPoint("TOPLEFT", self.ScrollUp, 1, -1)
-	self.ScrollUp.Texture:SetPoint("BOTTOMRIGHT", self.ScrollUp, -1, 1)
-	self.ScrollUp.Texture:SetTexture(Assets:GetTexture(Settings["ui-header-texture"]))
-	self.ScrollUp.Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
-
-	self.ScrollUp.Highlight = self.ScrollUp:CreateTexture(nil, "HIGHLIGHT")
-	self.ScrollUp.Highlight:SetPoint("TOPLEFT", self.ScrollUp, 1, -1)
-	self.ScrollUp.Highlight:SetPoint("BOTTOMRIGHT", self.ScrollUp, -1, 1)
-	self.ScrollUp.Highlight:SetTexture(Assets:GetTexture(Settings["ui-widget-texture"]))
-	self.ScrollUp.Highlight:SetVertexColor(1, 1, 1)
-	self.ScrollUp.Highlight:SetAlpha(SELECTED_HIGHLIGHT_ALPHA)
-
-	self.ScrollUp.Arrow = self.ScrollUp:CreateTexture(nil, "OVERLAY")
-	self.ScrollUp.Arrow:SetPoint("CENTER", self.ScrollUp, 0, 0)
-	self.ScrollUp.Arrow:SetSize(16, 16)
-	self.ScrollUp.Arrow:SetTexture(Assets:GetTexture("Arrow Up"))
-	self.ScrollUp.Arrow:SetVertexColor(0.65, 0.65, 0.65)
-
-	-- Scroll down
-	self.ScrollDown = CreateFrame("Frame", nil, self, "BackdropTemplate")
-	self.ScrollDown:SetSize(16, WIDGET_HEIGHT)
-	self.ScrollDown:SetPoint("BOTTOMRIGHT", GUI, -SPACING, SPACING)
-	self.ScrollDown:SetBackdrop(HydraUI.BackdropAndBorder)
-	self.ScrollDown:SetBackdropColor(0, 0, 0, 0)
-	self.ScrollDown:SetBackdropBorderColor(0, 0, 0)
-	self.ScrollDown:SetScript("OnMouseUp", function(self)
-		self.Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
-
-		WindowOnMouseWheel(self:GetParent(), -1)
-	end)
-
-	self.ScrollDown:SetScript("OnMouseDown", function(self)
-		local R, G, B = HydraUI:HexToRGB(Settings["ui-widget-bright-color"])
-
-		self.Texture:SetVertexColor(R * 0.85, G * 0.85, B * 0.85)
-	end)
-
-	self.ScrollDown.Texture = self.ScrollDown:CreateTexture(nil, "ARTWORK")
-	self.ScrollDown.Texture:SetPoint("TOPLEFT", self.ScrollDown, 1, -1)
-	self.ScrollDown.Texture:SetPoint("BOTTOMRIGHT", self.ScrollDown, -1, 1)
-	self.ScrollDown.Texture:SetTexture(Assets:GetTexture(Settings["ui-header-texture"]))
-	self.ScrollDown.Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
-
-	self.ScrollDown.Highlight = self.ScrollDown:CreateTexture(nil, "HIGHLIGHT")
-	self.ScrollDown.Highlight:SetPoint("TOPLEFT", self.ScrollDown, 1, -1)
-	self.ScrollDown.Highlight:SetPoint("BOTTOMRIGHT", self.ScrollDown, -1, 1)
-	self.ScrollDown.Highlight:SetTexture(Assets:GetTexture(Settings["ui-widget-texture"]))
-	self.ScrollDown.Highlight:SetVertexColor(1, 1, 1)
-	self.ScrollDown.Highlight:SetAlpha(SELECTED_HIGHLIGHT_ALPHA)
-
-	self.ScrollDown.Arrow = self.ScrollDown:CreateTexture(nil, "OVERLAY")
-	self.ScrollDown.Arrow:SetPoint("CENTER", self.ScrollDown, 0, 0)
-	self.ScrollDown.Arrow:SetSize(16, 16)
-	self.ScrollDown.Arrow:SetTexture(Assets:GetTexture("Arrow Down"))
-	self.ScrollDown.Arrow:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-color"]))
+        -- Scroll down
+        self.ScrollDown = CreateFrame("Frame", nil, self, "BackdropTemplate")
+        self.ScrollDown:SetSize(16, WIDGET_HEIGHT)
+        self.ScrollDown:SetPoint("BOTTOMRIGHT", GUI, -SPACING, SPACING)
+        StyleScrollButton(self.ScrollDown, "Arrow Down")
+        AttachScrollScripts(self.ScrollDown, -1)
 
 	local ScrollBar = CreateFrame("Slider", nil, self, "BackdropTemplate")
 	ScrollBar:SetPoint("TOPLEFT", self.ScrollUp, "BOTTOMLEFT", 0, -2)
@@ -240,7 +239,7 @@ local AddWindowScrollBar = function(self)
 	ScrollBar:SetOrientation("VERTICAL")
 	ScrollBar:SetValueStep(1)
 	ScrollBar:SetBackdrop(HydraUI.BackdropAndBorder)
-	ScrollBar:SetBackdropColor(HydraUI:HexToRGB(Settings["ui-window-main-color"]))
+        ScrollBar:SetBackdropColor(GetColorRGB("ui-window-main-color"))
 	ScrollBar:SetBackdropBorderColor(0, 0, 0)
 	ScrollBar:SetMinMaxValues(1, self.MaxScroll)
 	ScrollBar:SetValue(1)
@@ -264,8 +263,8 @@ local AddWindowScrollBar = function(self)
 	ScrollBar.NewThumb2 = ScrollBar:CreateTexture(nil, "OVERLAY")
 	ScrollBar.NewThumb2:SetPoint("TOPLEFT", ScrollBar.NewThumb, 1, -1)
 	ScrollBar.NewThumb2:SetPoint("BOTTOMRIGHT", ScrollBar.NewThumb, -1, 1)
-	ScrollBar.NewThumb2:SetTexture(Assets:GetTexture(Settings["ui-widget-texture"]))
-	ScrollBar.NewThumb2:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
+        ScrollBar.NewThumb2:SetTexture(Assets:GetTexture(Settings["ui-widget-texture"]))
+        ScrollBar.NewThumb2:SetVertexColor(GetColorRGB("ui-widget-bright-color"))
 
 	ScrollBar.Highlight = ScrollBar:CreateTexture(nil, "HIGHLIGHT")
 	ScrollBar.Highlight:SetPoint("TOPLEFT", ScrollBar.NewThumb, 1, -1)
@@ -277,8 +276,8 @@ local AddWindowScrollBar = function(self)
 	ScrollBar.Progress = ScrollBar:CreateTexture(nil, "ARTWORK")
 	ScrollBar.Progress:SetPoint("TOPLEFT", ScrollBar, 1, -1)
 	ScrollBar.Progress:SetPoint("BOTTOMRIGHT", ScrollBar.NewThumb, "TOPRIGHT", -1, 0)
-	ScrollBar.Progress:SetTexture(Assets:GetTexture("Blank"))
-	ScrollBar.Progress:SetVertexColor(HydraUI:HexToRGB(Settings["ui-widget-bright-color"]))
+        ScrollBar.Progress:SetTexture(Assets:GetTexture("Blank"))
+        ScrollBar.Progress:SetVertexColor(GetColorRGB("ui-widget-bright-color"))
 	ScrollBar.Progress:SetAlpha(SELECTED_HIGHLIGHT_ALPHA)
 
 	self:EnableMouseWheel(true)
@@ -359,7 +358,31 @@ function GUI:CreateCategory(name)
 end
 
 local DisableScrolling = function(self)
-	self.ScrollingDisabled = true
+        self.ScrollingDisabled = true
+end
+
+local RunLoadCalls = function(self, category, name, parent, leftColumn, rightColumn)
+        local queue
+
+        if parent then
+                local categoryData = self.LoadCalls[category]
+                local parentData = categoryData and categoryData[parent]
+                local children = parentData and parentData.Children
+                queue = children and children[name] and children[name].Calls
+        else
+                local categoryData = self.LoadCalls[category]
+                queue = categoryData and categoryData[name] and categoryData[name].Calls
+        end
+
+        if (not queue or #queue == 0) then
+                return
+        end
+
+        for i = 1, #queue do
+                queue[i](leftColumn, rightColumn)
+        end
+
+        ClearTable(queue)
 end
 
 function GUI:CreateWidgetWindow(category, name, parent)
@@ -413,19 +436,7 @@ function GUI:CreateWidgetWindow(category, name, parent)
 		Window.RightWidgetsBG[Name] = Function
 	end
 
-	if (parent and self.LoadCalls[category][parent].Children) then
-		for i = 1, #self.LoadCalls[category][parent].Children[name].Calls do
-			self.LoadCalls[category][parent].Children[name].Calls[1](Window.LeftWidgetsBG, Window.RightWidgetsBG)
-
-			tremove(self.LoadCalls[category][parent].Children[name].Calls, 1)
-		end
-	else
-		for i = 1, #self.LoadCalls[category][name].Calls do
-			self.LoadCalls[category][name].Calls[1](Window.LeftWidgetsBG, Window.RightWidgetsBG)
-
-			tremove(self.LoadCalls[category][name].Calls, 1)
-		end
-	end
+        RunLoadCalls(self, category, name, parent, Window.LeftWidgetsBG, Window.RightWidgetsBG)
 
 	if (#Window.LeftWidgetsBG.Widgets > 0) then
 		Window.LeftWidgetsBG:CreateFooter()
@@ -1301,11 +1312,15 @@ function GUI:CreateGUI()
 	self.CloseButton.Cross:SetTexture(Assets:GetTexture("Close"))
 	self.CloseButton.Cross:SetVertexColor(HydraUI:HexToRGB("EEEEEE"))
 
-	for i = 1, #self.ButtonQueue do
-		self:CreateWindow(unpack(tremove(self.ButtonQueue, 1)))
-	end
+        local buttonQueue = self.ButtonQueue
 
-	self:SortMenuButtons()
+        for i = 1, #buttonQueue do
+                self:CreateWindow(unpack(buttonQueue[i]))
+        end
+
+        ClearTable(buttonQueue)
+
+        self:SortMenuButtons()
 
 	self.ScrollBar:SetMinMaxValues(1, ((self.NumShownButtons or 15) - MAX_WIDGETS_SHOWN) + 1)
 	self.ScrollBar:SetValue(1)

--- a/HydraUI/Elements/GUI/Widgets.lua
+++ b/HydraUI/Elements/GUI/Widgets.lua
@@ -1,6 +1,7 @@
 local HydraUI, Language, Assets, Settings, Defaults = select(2, ...):get()
 
 -- Locals
+local format = format
 local type = type
 local next = next
 local tonumber = tonumber
@@ -31,9 +32,21 @@ local LAST_ACTIVE_DROPDOWN
 
 local GUI = HydraUI:GetModule("GUI")
 
+local FormatColor = function(color, text)
+        return format("|cFF%s%s|r", color, tostring(text))
+end
+
+local RegisterWidget = function(self, widget, id)
+        tinsert(self.Widgets, widget)
+
+        if (id and id ~= "") then
+                GUI.WidgetID[id] = widget
+        end
+end
+
 local Ignore = {
-	["ui-profile"] = true,
-	["profile-copy"] = true,
+        ["ui-profile"] = true,
+        ["profile-copy"] = true,
 }
 
 -- Functions
@@ -92,17 +105,13 @@ GUI.Widgets.CreateLine = function(self, id, text)
 	Text:SetSize(GROUP_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Text:SetJustifyH("LEFT")
-	Text:SetText(format("|cFF%s%s|r", Settings["ui-widget-font-color"], tostring(text)))
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], text))
 
-	Anchor.Text = Text
+        Anchor.Text = Text
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor, id)
 
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
-
-	return Text
+        return Text
 end
 
 -- Double Line
@@ -115,25 +124,21 @@ GUI.Widgets.CreateDoubleLine = function(self, id, left, right)
 	Left:SetSize((GROUP_WIDTH / 2) - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Left, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Left:SetJustifyH("LEFT")
-	Left:SetText(format("|cFF%s%s|r", Settings["ui-widget-font-color"], tostring(left)))
+        Left:SetText(FormatColor(Settings["ui-widget-font-color"], left))
 
 	local Right = Anchor:CreateFontString(nil, "OVERLAY")
 	Right:SetPoint("RIGHT", Anchor, -HEADER_SPACING, 0)
 	Right:SetSize((GROUP_WIDTH / 2) - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Right, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Right:SetJustifyH("RIGHT")
-	Right:SetText(format("|cFF%s%s|r", Settings["ui-widget-font-color"], tostring(right)))
+        Right:SetText(FormatColor(Settings["ui-widget-font-color"], right))
 
 	Anchor.Left = Left
 	Anchor.Right = Right
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor, id)
 
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
-
-	return Left
+        return Left
 end
 
 -- Message
@@ -198,7 +203,7 @@ GUI.Widgets.CreateAnimatedLine = function(self, id, left, right, r, g, b)
 	Left:SetSize(GROUP_WIDTH - 8, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Left, Settings["ui-widget-font"], 16)
 	Left:SetJustifyH("LEFT")
-	Left:SetText(format("|cFF%s%s|r", Settings["ui-widget-font-color"], left))
+        Left:SetText(FormatColor(Settings["ui-widget-font-color"], left))
 
 	local Parent = CreateFrame("Frame", nil, Anchor)
 	Parent:SetSize(Left:GetStringWidth() + 8, WIDGET_HEIGHT + 4)
@@ -249,11 +254,7 @@ GUI.Widgets.CreateAnimatedLine = function(self, id, left, right, r, g, b)
 	ScaleOut:SetOrder(2)
 	ScaleOut:SetGroup(Group)
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 end
 
 GUI.Widgets.CreateAnimatedDoubleLine = function(self, id, left, right, r, g, b)
@@ -366,13 +367,9 @@ GUI.Widgets.CreateAnimatedDoubleLine = function(self, id, left, right, r, g, b)
 		Anchor.RightParent.SOut:SetOrder(2)
 	end
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor, id)
 
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
-
-	return Anchor.Left, Anchor.Right
+        return Anchor.Left, Anchor.Right
 end
 
 GUI.Widgets.CreateHeader = function(self, text)
@@ -385,7 +382,7 @@ GUI.Widgets.CreateHeader = function(self, text)
 	Text:SetHeight(WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-header-font"], 12)
 	Text:SetJustifyH("CENTER")
-	Text:SetText("|cFF"..Settings["ui-header-font-color"]..text.."|r")
+        Text:SetText(FormatColor(Settings["ui-header-font-color"], text))
 
 	local BG = Anchor:CreateTexture(nil, "BORDER")
 	BG:SetAllPoints()
@@ -397,9 +394,9 @@ GUI.Widgets.CreateHeader = function(self, text)
 	Texture:SetTexture(Assets:GetTexture("Blank"))
 	Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-header-texture-color"]))
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor)
 
-	return Text
+        return Text
 end
 
 -- Footer
@@ -418,7 +415,7 @@ GUI.Widgets.CreateFooter = function(self)
 	Texture:SetTexture(Assets:GetTexture("Blank"))
 	Texture:SetVertexColor(HydraUI:HexToRGB(Settings["ui-header-texture-color"]))
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor)
 end
 
 -- Button
@@ -519,7 +516,7 @@ GUI.Widgets.CreateButton = function(self, id, value, label, tooltip, hook)
 	Text:SetSize(GROUP_WIDTH - BUTTON_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Text:SetJustifyH("LEFT")
-	Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	Button.Texture = Texture
 	Button.Highlight = Highlight
@@ -528,11 +525,7 @@ GUI.Widgets.CreateButton = function(self, id, value, label, tooltip, hook)
 
 	Anchor.Button = Button
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 
 	return Anchor
 end
@@ -599,20 +592,16 @@ GUI.Widgets.CreateStatusBar = function(self, id, value, minvalue, maxvalue, labe
 	Text:SetSize(GROUP_WIDTH - STATUSBAR_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Text:SetJustifyH("LEFT")
-	Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	Bar.Anim = Anim
 	Bar.Spark = Spark
 	Bar.MiddleText = MiddleText
 	Bar.Text = Text
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor, id)
 
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
-
-	return Bar
+        return Bar
 end
 
 -- Checkbox
@@ -703,7 +692,7 @@ GUI.Widgets.CreateCheckbox = function(self, id, value, label, tooltip, hook)
 	Text:SetSize(GROUP_WIDTH - CHECKBOX_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Text:SetJustifyH("LEFT")
-	Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	local Hover = Checkbox:CreateTexture(nil, "HIGHLIGHT")
 	Hover:SetPoint("TOPLEFT", Checkbox, 1, -1)
@@ -735,11 +724,7 @@ GUI.Widgets.CreateCheckbox = function(self, id, value, label, tooltip, hook)
 	Checkbox.FadeIn = FadeIn
 	Checkbox.FadeOut = FadeOut
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 
 	return Checkbox
 end
@@ -894,7 +879,7 @@ GUI.Widgets.CreateSwitch = function(self, id, value, label, tooltip, hook)
 	Text:SetSize(GROUP_WIDTH - SWITCH_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Text:SetJustifyH("LEFT")
-	Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	local Highlight = Switch:CreateTexture(nil, "HIGHLIGHT")
 	Highlight:SetPoint("TOPLEFT", Switch, 1, -1)
@@ -914,11 +899,7 @@ GUI.Widgets.CreateSwitch = function(self, id, value, label, tooltip, hook)
 
 	Anchor.Switch = Switch
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 
 	return Switch
 end
@@ -1020,7 +1001,7 @@ function GUI:CreateInputWindow()
 	Window.Header.Text:SetPoint("LEFT", Window.Header, HEADER_SPACING, -1)
 	HydraUI:SetFontInfo(Window.Header.Text, Settings["ui-header-font"], Settings["ui-header-font-size"])
 	Window.Header.Text:SetJustifyH("LEFT")
-	Window.Header.Text:SetText("|cFF" .. Settings["ui-header-font-color"] .. Language["Input"] .. "|r")
+        Window.Header.Text:SetText(FormatColor(Settings["ui-header-font-color"], Language["Input"]))
 
 	-- Close button
 	Window.CloseButton = CreateFrame("Frame", nil, Window, "BackdropTemplate")
@@ -1191,7 +1172,7 @@ GUI.Widgets.CreateInput = function(self, id, value, label, tooltip, hook)
 	Input.Text:SetSize(GROUP_WIDTH - INPUT_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Input.Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Input.Text:SetJustifyH("LEFT")
-	Input.Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Input.Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	Input.FadeIn = LibMotion:CreateAnimation(Input.Flash, "Fade")
 	Input.FadeIn:SetEasing("in")
@@ -1204,11 +1185,7 @@ GUI.Widgets.CreateInput = function(self, id, value, label, tooltip, hook)
 	Input.FadeOut:SetDuration(0.3)
 	Input.FadeOut:SetChange(0)
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 
 	Anchor.Input = Input
 
@@ -1243,7 +1220,7 @@ GUI.Widgets.CreateInputWithButton = function(self, id, value, button, label, too
 	Text:SetJustifyH("LEFT")
 	Text:SetShadowColor(0, 0, 0)
 	Text:SetShadowOffset(1, -1)
-	Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	local Anchor2 = CreateFrame("Frame", nil, self)
 	Anchor2:SetSize(GROUP_WIDTH, WIDGET_HEIGHT)
@@ -1346,8 +1323,8 @@ GUI.Widgets.CreateInputWithButton = function(self, id, value, button, label, too
 	Input.FadeOut:SetDuration(0.3)
 	Input.FadeOut:SetChange(0)
 
-	tinsert(self.Widgets, Anchor)
-	tinsert(self.Widgets, Anchor2)
+        RegisterWidget(self, Anchor, id)
+        RegisterWidget(self, Anchor2)
 
 	Anchor.Input = Input
 
@@ -1430,7 +1407,7 @@ function GUI:CreateExportWindow()
 	Window.Header.Text:SetPoint("LEFT", Window.Header, HEADER_SPACING, -1)
 	HydraUI:SetFontInfo(Window.Header.Text, Settings["ui-header-font"], Settings["ui-header-font-size"])
 	Window.Header.Text:SetJustifyH("LEFT")
-	Window.Header.Text:SetText("|cFF"..Settings["ui-header-font-color"]..Language["Export string"].."|r")
+        Window.Header.Text:SetText(FormatColor(Settings["ui-header-font-color"], Language["Export string"]))
 
 	-- Close button
 	Window.Header.CloseButton = CreateFrame("Frame", nil, Window.Header)
@@ -1602,7 +1579,7 @@ function GUI:CreateImportWindow()
 	Window.Header.Text:SetPoint("LEFT", Window.Header, HEADER_SPACING, -1)
 	HydraUI:SetFontInfo(Window.Header.Text, Settings["ui-header-font"], Settings["ui-header-font-size"])
 	Window.Header.Text:SetJustifyH("LEFT")
-	Window.Header.Text:SetText("|cFF"..Settings["ui-header-font-color"].."Import string".."|r")
+        Window.Header.Text:SetText(FormatColor(Settings["ui-header-font-color"], "Import string"))
 
 	-- Close button
 	Window.Header.CloseButton = CreateFrame("Frame", nil, Window.Header)
@@ -2096,7 +2073,7 @@ GUI.Widgets.CreateDropdown = function(self, id, value, values, label, tooltip, h
 	Dropdown.Text:SetSize(GROUP_WIDTH - DROPDOWN_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Dropdown.Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Dropdown.Text:SetJustifyH("LEFT")
-	Dropdown.Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Dropdown.Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	Dropdown.ArrowAnchor = CreateFrame("Frame", nil, Dropdown)
 	Dropdown.ArrowAnchor:SetSize(WIDGET_HEIGHT, WIDGET_HEIGHT)
@@ -2189,13 +2166,11 @@ GUI.Widgets.CreateDropdown = function(self, id, value, values, label, tooltip, h
 
 	Anchor.Dropdown = Dropdown
 
-	if self.Widgets then
-		tinsert(self.Widgets, Anchor)
-	end
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        if self.Widgets then
+                RegisterWidget(self, Anchor, id)
+        elseif (id ~= "") then
+                GUI.WidgetID[id] = Anchor
+        end
 
 	return Dropdown
 end
@@ -2487,7 +2462,7 @@ GUI.Widgets.CreateSlider = function(self, id, value, minvalue, maxvalue, step, l
 	Slider.Text:SetSize(GROUP_WIDTH - SLIDER_WIDTH - EDITBOX_WIDTH - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Slider.Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Slider.Text:SetJustifyH("LEFT")
-	Slider.Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Slider.Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
 	Slider.TrackTexture = Slider:CreateTexture(nil, "ARTWORK")
 	Slider.TrackTexture:SetPoint("TOPLEFT", Slider, 1, -1)
@@ -2532,11 +2507,7 @@ GUI.Widgets.CreateSlider = function(self, id, value, minvalue, maxvalue, step, l
 
 	Slider:Show()
 
-	tinsert(self.Widgets, Anchor)
-
-	if (id ~= "") then
-		GUI.WidgetID[id] = Anchor
-	end
+        RegisterWidget(self, Anchor, id)
 
 	return Slider
 end
@@ -2727,7 +2698,7 @@ local CreateColorPicker = function()
 	ColorPicker.Header.Text:SetPoint("LEFT", ColorPicker.Header, HEADER_SPACING, -1)
 	HydraUI:SetFontInfo(ColorPicker.Header.Text, Settings["ui-header-font"], Settings["ui-header-font-size"])
 	ColorPicker.Header.Text:SetJustifyH("LEFT")
-	ColorPicker.Header.Text:SetText("|cFF"..Settings["ui-header-font-color"].."Select a color".."|r")
+        ColorPicker.Header.Text:SetText(FormatColor(Settings["ui-header-font-color"], "Select a color"))
 
 	-- Close button
 	ColorPicker.CloseButton = CreateFrame("Frame", nil, ColorPicker, "BackdropTemplate")
@@ -2921,7 +2892,7 @@ local CreateColorPicker = function()
 	ColorPicker.AcceptText:SetPoint("CENTER", ColorPicker.Accept, 0, 0)
 	HydraUI:SetFontInfo(ColorPicker.AcceptText, Settings["ui-button-font"], Settings["ui-font-size"])
 	ColorPicker.AcceptText:SetJustifyH("CENTER")
-	ColorPicker.AcceptText:SetText("|cFF"..Settings["ui-button-font-color"]..ACCEPT.."|r")
+        ColorPicker.AcceptText:SetText(FormatColor(Settings["ui-button-font-color"], ACCEPT))
 
 	-- Cancel
 	ColorPicker.Cancel = CreateFrame("Frame", nil, ColorPicker, "BackdropTemplate")
@@ -2952,7 +2923,7 @@ local CreateColorPicker = function()
 	ColorPicker.CancelText:SetPoint("CENTER", ColorPicker.Cancel, 0, 0)
 	HydraUI:SetFontInfo(ColorPicker.CancelText, Settings["ui-button-font"], Settings["ui-font-size"])
 	ColorPicker.CancelText:SetJustifyH("CENTER")
-	ColorPicker.CancelText:SetText("|cFF"..Settings["ui-button-font-color"]..CANCEL.."|r")
+        ColorPicker.CancelText:SetText(FormatColor(Settings["ui-button-font-color"], CANCEL))
 
 	ColorPicker.BG = CreateFrame("Frame", nil, ColorPicker, "BackdropTemplate")
 	ColorPicker.BG:SetPoint("TOPLEFT", ColorPicker.Header, -3, 3)
@@ -3191,9 +3162,9 @@ GUI.Widgets.CreateColorSelection = function(self, id, value, label, tooltip, hoo
 	Button.Text:SetSize(GROUP_WIDTH - COLOR_WIDTH - SWATCH_SIZE - 6, WIDGET_HEIGHT)
 	HydraUI:SetFontInfo(Button.Text, Settings["ui-widget-font"], Settings["ui-font-size"])
 	Button.Text:SetJustifyH("LEFT")
-	Button.Text:SetText("|cFF"..Settings["ui-widget-font-color"]..label.."|r")
+        Button.Text:SetText(FormatColor(Settings["ui-widget-font-color"], label))
 
-	tinsert(self.Widgets, Anchor)
+        RegisterWidget(self, Anchor)
 
-	return Button
+        return Button
 end


### PR DESCRIPTION
## Summary
- deduplicate widget color lookups and streamline layout/scroll handling in the configuration window
- add helpers for formatting text and registering widgets to keep widget definitions consistent across the GUI
- streamline widget load queues and scroll offset updates to avoid redundant work when windows are shown or scrolled

## Testing
- not run (UI addon)

------
https://chatgpt.com/codex/tasks/task_e_68d642e595f0832fbdd526defba47958