### PR TITLE
Localize right window configuration strings

### DIFF
--- a/HydraUI/Elements/Chat.lua
+++ b/HydraUI/Elements/Chat.lua
@@ -1656,7 +1656,7 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 	local Left = left:CreateSlider("right-window-left-fill", Settings["right-window-left-fill"], 0, 100, 5, Language["Left Opacity"], Language["Set the opacity of the left window background"], UpdateLeftOpacity, nil, "%")
 	local Right = left:CreateSlider("right-window-right-fill", Settings["right-window-right-fill"], 0, 100, 5, Language["Right Opacity"], Language["Set the opacity of the right window background"], UpdateRightOpacity, nil, "%")
 
-	left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, "Set divider", "blah", UpdateSplitPosition, nil, "%")
+left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, Language["Divider Position"], Language["Set the position of the divider between chat windows"], UpdateSplitPosition, nil, "%")
 
 	if (Settings["right-window-size"] == "SINGLE") then
 		Left:GetParent():Disable()
@@ -1665,9 +1665,9 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 		Single:GetParent():Disable()
 	end
 
-	right:CreateHeader("Window Style")
+right:CreateHeader(Language["Window Style"])
 	right:CreateDropdown("right-window-size", Settings["right-window-size"], {[Language["Single"]] = "SINGLE", [Language["Double"]] = "DOUBLE"}, Language["Set Window Size"], Language["Set the number of windows to be displayed"], ReloadUI):RequiresReload(true)
 
-	right:CreateHeader("Single Window Embed")
+right:CreateHeader(Language["Single Window Embed"])
 	right:CreateDropdown("rw-single-embed", Settings["rw-single-embed"], GetChatFrameList(), Language["Select Chat"], Language["Set which chat frame should be in the right window"], UpdateRightChatWindow)
 end)

--- a/HydraUI/Elements/Chat/Chat.lua
+++ b/HydraUI/Elements/Chat/Chat.lua
@@ -1656,7 +1656,7 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 	local Left = left:CreateSlider("right-window-left-fill", Settings["right-window-left-fill"], 0, 100, 5, Language["Left Opacity"], Language["Set the opacity of the left window background"], UpdateLeftOpacity, nil, "%")
 	local Right = left:CreateSlider("right-window-right-fill", Settings["right-window-right-fill"], 0, 100, 5, Language["Right Opacity"], Language["Set the opacity of the right window background"], UpdateRightOpacity, nil, "%")
 
-	left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, "Set divider", "blah", UpdateSplitPosition, nil, "%")
+left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, Language["Divider Position"], Language["Set the position of the divider between chat windows"], UpdateSplitPosition, nil, "%")
 
 	if (Settings["right-window-size"] == "SINGLE") then
 		Left:GetParent():Disable()
@@ -1665,9 +1665,9 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 		Single:GetParent():Disable()
 	end
 
-	right:CreateHeader("Window Style")
+right:CreateHeader(Language["Window Style"])
 	right:CreateDropdown("right-window-size", Settings["right-window-size"], {[Language["Single"]] = "SINGLE", [Language["Double"]] = "DOUBLE"}, Language["Set Window Size"], Language["Set the number of windows to be displayed"], ReloadUI):RequiresReload(true)
 
-	right:CreateHeader("Single Window Embed")
+right:CreateHeader(Language["Single Window Embed"])
 	right:CreateDropdown("rw-single-embed", Settings["rw-single-embed"], GetChatFrameList(), Language["Select Chat"], Language["Set which chat frame should be in the right window"], UpdateRightChatWindow)
 end)

--- a/HydraUI/Elements/Chat/Filters.lua
+++ b/HydraUI/Elements/Chat/Filters.lua
@@ -1656,7 +1656,7 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 	local Left = left:CreateSlider("right-window-left-fill", Settings["right-window-left-fill"], 0, 100, 5, Language["Left Opacity"], Language["Set the opacity of the left window background"], UpdateLeftOpacity, nil, "%")
 	local Right = left:CreateSlider("right-window-right-fill", Settings["right-window-right-fill"], 0, 100, 5, Language["Right Opacity"], Language["Set the opacity of the right window background"], UpdateRightOpacity, nil, "%")
 
-	left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, "Set divider", "blah", UpdateSplitPosition, nil, "%")
+left:CreateSlider("right-window-middle-pos", Settings["right-window-middle-pos"], 1, 99, 1, Language["Divider Position"], Language["Set the position of the divider between chat windows"], UpdateSplitPosition, nil, "%")
 
 	if (Settings["right-window-size"] == "SINGLE") then
 		Left:GetParent():Disable()
@@ -1665,9 +1665,9 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Right"], Lang
 		Single:GetParent():Disable()
 	end
 
-	right:CreateHeader("Window Style")
+right:CreateHeader(Language["Window Style"])
 	right:CreateDropdown("right-window-size", Settings["right-window-size"], {[Language["Single"]] = "SINGLE", [Language["Double"]] = "DOUBLE"}, Language["Set Window Size"], Language["Set the number of windows to be displayed"], ReloadUI):RequiresReload(true)
 
-	right:CreateHeader("Single Window Embed")
+right:CreateHeader(Language["Single Window Embed"])
 	right:CreateDropdown("rw-single-embed", Settings["rw-single-embed"], GetChatFrameList(), Language["Select Chat"], Language["Set which chat frame should be in the right window"], UpdateRightChatWindow)
 end)

--- a/HydraUI/Elements/Credit.lua
+++ b/HydraUI/Elements/Credit.lua
@@ -90,6 +90,6 @@ GUI:AddWidgets(Language["Info"], Language["Supporters"], function(left, right)
 	right:CreateHeader(Language["Donors"])
 	right:CreateMessage("", Donors)
 
-	right:CreateHeader("Thank you so much!")
-	right:CreateMessage("", "Thank you to all of these amazing people for their support, through donations and Patreon pledges! This generosity allows me to spend so much of my time developing the interface for everyone.")
+right:CreateHeader(Language["Thank you so much!"])
+right:CreateMessage("", Language["Thank you to all of these amazing people for their support, through donations and Patreon pledges! This generosity allows me to spend so much of my time developing the interface for everyone."])
 end)

--- a/HydraUI/Elements/Experience.lua
+++ b/HydraUI/Elements/Experience.lua
@@ -653,7 +653,7 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Experience"],
 	right:CreateDropdown("experience-progress-visibility", Settings["experience-progress-visibility"], {[Language["Always Show"]] = "ALWAYS", [Language["Mouseover"]] = "MOUSEOVER"}, Language["Progress Text"], Language["Set when to display the progress information"], UpdateProgressVisibility)
 	right:CreateDropdown("experience-percent-visibility", Settings["experience-percent-visibility"], {[Language["Always Show"]] = "ALWAYS", [Language["Mouseover"]] = "MOUSEOVER"}, Language["Percent Text"], Language["Set when to display the percent information"], UpdatePercentVisibility)
 
-	left:CreateHeader("Mouseover")
+left:CreateHeader(Language["Mouseover"])
 	left:CreateSwitch("experience-mouseover", Settings["experience-mouseover"], Language["Display On Mouseover"], Language["Only display the experience bar while mousing over it"], UpdateMouseover)
 	left:CreateSlider("experience-mouseover-opacity", Settings["experience-mouseover-opacity"], 0, 100, 5, Language["Mouseover Opacity"], Language["Set the opacity of the experience bar while not mousing over it"], UpdateMouseoverOpacity, nil, "%")
 end)

--- a/HydraUI/Elements/GUI/GUI.lua
+++ b/HydraUI/Elements/GUI/GUI.lua
@@ -1196,7 +1196,7 @@ function GUI:CreateUpdateAlert()
 	HydraUI:SetFontInfo(self.Alert.Text, Settings["ui-header-font"], Settings["ui-font-size"])
 	self.Alert.Text:SetJustifyH("LEFT")
 	self.Alert.Text:SetTextColor(GetColorRGB("ui-widget-color"))
-	self.Alert.Text:SetText("Update available") -- localize
+        self.Alert.Text:SetText(Language["Update available"])
 
 	self.Alert:SetWidth(self.Alert.Text:GetStringWidth() + 32)
 

--- a/HydraUI/Elements/Languages/deDE.lua
+++ b/HydraUI/Elements/Languages/deDE.lua
@@ -676,6 +676,10 @@ L["Window Width"] = "Fensterbreite"
 L["Set the width of the window"] = "Legt die Breite des Fensters fest"
 L["Window Height"] = "Fensterhöhe"
 L["Set the height of the window"] = "Legt die Höhe des Fensters fest"
+L["Window Style"] = "Fensterstil"
+L["Single Window Embed"] = "Einzelfenster-Einbettung"
+L["Divider Position"] = "Position des Trenners"
+L["Set the position of the divider between chat windows"] = "Legt die Position des Trenners zwischen den Chatfenstern fest"
 L["Set the opacity of the window background"] = "Legt die Deckkraft des Fensterhintergrunds fest"
 L["Right Window Texts"] = "Texte des rechten Fensters"
 
@@ -779,5 +783,6 @@ L["Display the timer on unit frame auras"] = "Zeigt die Dauer auf den Einheitenf
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Eine aktualisierte Version von HydraUI findest du unter https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Update verfügbar"
 L["New Version!"] = "Neue Version!"
 L["Update to version |cFF%s%s|r"] = "Aktualisiere auf Version |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/esES.lua
+++ b/HydraUI/Elements/Languages/esES.lua
@@ -665,6 +665,10 @@ L["Window Width"] = "Anchura de la ventana"
 L["Set the width of the window"] = "Define la anchura de la ventana"
 L["Window Height"] = "Altura de la ventana"
 L["Set the height of the window"] = "Define la altura de la ventana"
+L["Window Style"] = "Estilo de ventana"
+L["Single Window Embed"] = "Incrustación de ventana única"
+L["Divider Position"] = "Posición del divisor"
+L["Set the position of the divider between chat windows"] = "Establece la posición del divisor entre las ventanas de chat"
 L["Set the opacity of the window background"] = "Define la opacidad del fondo de la ventana"
 L["Right Window Texts"] = "Textos de la ventana derecha"
 
@@ -763,5 +767,6 @@ L["Display the timer on unit frame auras"] = "Muestra el temporizador en las aur
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Puedes obtener una versión actualizada de HydraUI en https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Actualización disponible"
 L["New Version!"] = "¡Nueva versión!"
 L["Update to version |cFF%s%s|r"] = "Actualiza a la versión |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/esMX.lua
+++ b/HydraUI/Elements/Languages/esMX.lua
@@ -665,6 +665,10 @@ L["Window Width"] = "Ancho de la ventana"
 L["Set the width of the window"] = "Establece el ancho de la ventana"
 L["Window Height"] = "Altura de la ventana"
 L["Set the height of the window"] = "Establece la altura de la ventana"
+L["Window Style"] = "Estilo de ventana"
+L["Single Window Embed"] = "Incrustación de ventana única"
+L["Divider Position"] = "Posición del divisor"
+L["Set the position of the divider between chat windows"] = "Establece la posición del divisor entre las ventanas de chat"
 L["Set the opacity of the window background"] = "Establece la opacidad del fondo de la ventana"
 L["Right Window Texts"] = "Textos de la ventana derecha"
 
@@ -763,5 +767,6 @@ L["Display the timer on unit frame auras"] = "Muestra el temporizador en las aur
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Puedes obtener una versión actualizada de HydraUI en https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Actualización disponible"
 L["New Version!"] = "¡Nueva versión!"
 L["Update to version |cFF%s%s|r"] = "Actualiza a la versión |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/frFR.lua
+++ b/HydraUI/Elements/Languages/frFR.lua
@@ -1664,6 +1664,10 @@ L["Window Width"] = "Largeur de la fenêtre"
 L["Set the width of the window"] = "Définit la largeur de la fenêtre"
 L["Window Height"] = "Hauteur de la fenêtre"
 L["Set the height of the window"] = "Définit la hauteur de la fenêtre"
+L["Window Style"] = "Style de fenêtre"
+L["Single Window Embed"] = "Intégration fenêtre unique"
+L["Divider Position"] = "Position du séparateur"
+L["Set the position of the divider between chat windows"] = "Définit la position du séparateur entre les fenêtres de discussion"
 L["Set the opacity of the window background"] = "Définit l'opacité de l'arrière-plan de la fenêtre"
 L["Right Window Texts"] = "Textes de la fenêtre droite"
 
@@ -1760,5 +1764,6 @@ L["Display the timer on unit frame auras"] = "Affiche le minuteur sur les auras 
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Vous pouvez obtenir une version mise à jour d'HydraUI sur https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Mise à jour disponible"
 L["New Version!"] = "Nouvelle version !"
 L["Update to version |cFF%s%s|r"] = "Mettre à jour vers la version |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/itIT.lua
+++ b/HydraUI/Elements/Languages/itIT.lua
@@ -674,6 +674,10 @@ L["Window Width"] = "Larghezza finestra"
 L["Set the width of the window"] = "Imposta la larghezza della finestra"
 L["Window Height"] = "Altezza finestra"
 L["Set the height of the window"] = "Imposta l'altezza della finestra"
+L["Window Style"] = "Stile della finestra"
+L["Single Window Embed"] = "Incorpora finestra singola"
+L["Divider Position"] = "Posizione del divisore"
+L["Set the position of the divider between chat windows"] = "Imposta la posizione del divisore tra le finestre della chat"
 L["Set the opacity of the window background"] = "Imposta l'opacità dello sfondo della finestra"
 L["Right Window Texts"] = "Testi finestra destra"
 
@@ -777,5 +781,6 @@ L["Display the timer on unit frame auras"] = "Mostra il timer sulle aure dei riq
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Puoi scaricare una versione aggiornata di HydraUI su https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Aggiornamento disponibile"
 L["New Version!"] = "Nuova versione!"
 L["Update to version |cFF%s%s|r"] = "Aggiorna alla versione |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/koKR.lua
+++ b/HydraUI/Elements/Languages/koKR.lua
@@ -676,6 +676,10 @@ L["Window Width"] = "창 너비"
 L["Set the width of the window"] = "창의 너비를 설정합니다"
 L["Window Height"] = "창 높이"
 L["Set the height of the window"] = "창의 높이를 설정합니다"
+L["Window Style"] = "창 스타일"
+L["Single Window Embed"] = "단일 창 임베드"
+L["Divider Position"] = "구분선 위치"
+L["Set the position of the divider between chat windows"] = "채팅 창 사이의 구분선 위치를 설정합니다"
 L["Set the opacity of the window background"] = "창 배경의 불투명도를 설정합니다"
 L["Right Window Texts"] = "오른쪽 창 텍스트"
 
@@ -779,5 +783,6 @@ L["Display the timer on unit frame auras"] = "유닛 프레임 오라에 타이�
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "https://www.curseforge.com/wow/addons/hydraui에서 최신 버전의 HydraUI를 받을 수 있습니다"
+L["Update available"] = "업데이트 가능"
 L["New Version!"] = "새 버전!"
 L["Update to version |cFF%s%s|r"] = "|cFF%s%s|r 버전으로 업데이트"

--- a/HydraUI/Elements/Languages/ptBR.lua
+++ b/HydraUI/Elements/Languages/ptBR.lua
@@ -676,6 +676,10 @@ L["Window Width"] = "Largura da janela"
 L["Set the width of the window"] = "Define a largura da janela"
 L["Window Height"] = "Altura da janela"
 L["Set the height of the window"] = "Define a altura da janela"
+L["Window Style"] = "Estilo da janela"
+L["Single Window Embed"] = "Incorporação de janela única"
+L["Divider Position"] = "Posição do divisor"
+L["Set the position of the divider between chat windows"] = "Define a posição do divisor entre as janelas de bate-papo"
 L["Set the opacity of the window background"] = "Define a opacidade do fundo da janela"
 L["Right Window Texts"] = "Textos da janela direita"
 
@@ -779,5 +783,6 @@ L["Display the timer on unit frame auras"] = "Mostra o tempo restante nas auras 
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Você pode obter uma versão atualizada do HydraUI em https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Atualização disponível"
 L["New Version!"] = "Nova versão!"
 L["Update to version |cFF%s%s|r"] = "Atualize para a versão |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/ruRU.lua
+++ b/HydraUI/Elements/Languages/ruRU.lua
@@ -675,6 +675,10 @@ L["Window Width"] = "Ширина окна"
 L["Set the width of the window"] = "Задать ширину окна"
 L["Window Height"] = "Высота окна"
 L["Set the height of the window"] = "Задать высоту окна"
+L["Window Style"] = "Стиль окна"
+L["Single Window Embed"] = "Встраивание одиночного окна"
+L["Divider Position"] = "Положение разделителя"
+L["Set the position of the divider between chat windows"] = "Задает положение разделителя между окнами чата"
 L["Set the opacity of the window background"] = "Задать прозрачность фона окна"
 L["Right Window Texts"] = "Инфотексты правого окна"
 
@@ -771,5 +775,6 @@ L["Display the timer on unit frame auras"] = "Показывать таймер 
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "Получите последнюю версию HydraUI на https://www.curseforge.com/wow/addons/hydraui"
+L["Update available"] = "Доступно обновление"
 L["New Version!"] = "Новая версия!"
 L["Update to version |cFF%s%s|r"] = "Обновитесь до версии |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/zhCN.lua
+++ b/HydraUI/Elements/Languages/zhCN.lua
@@ -676,6 +676,10 @@ L["Window Width"] = "窗口寬度"
 L["Set the width of the window"] = "设置窗口寬度"
 L["Window Height"] = "窗口高度"
 L["Set the height of the window"] = "设置窗口高度"
+L["Window Style"] = "窗口样式"
+L["Single Window Embed"] = "单窗口嵌入"
+L["Divider Position"] = "分隔条位置"
+L["Set the position of the divider between chat windows"] = "设置聊天窗口之间分隔条的位置"
 L["Set the opacity of the window background"] = "设置窗口背景不透明度"
 L["Right Window Texts"] = "右側窗口文字"
 
@@ -779,5 +783,6 @@ L["Display the timer on unit frame auras"] = "在单位框架光环上显示计�
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "可于 https://www.curseforge.com/wow/addons/hydraui 获取 HydraUI 最新版本"
+L["Update available"] = "有可用更新"
 L["New Version!"] = "新版本！"
 L["Update to version |cFF%s%s|r"] = "更新至版本 |cFF%s%s|r"

--- a/HydraUI/Elements/Languages/zhTW.lua
+++ b/HydraUI/Elements/Languages/zhTW.lua
@@ -676,6 +676,10 @@ L["Window Width"] = "視窗寬度"
 L["Set the width of the window"] = "設定視窗寬度"
 L["Window Height"] = "視窗高度"
 L["Set the height of the window"] = "設定視窗高度"
+L["Window Style"] = "視窗樣式"
+L["Single Window Embed"] = "單一視窗嵌入"
+L["Divider Position"] = "分隔線位置"
+L["Set the position of the divider between chat windows"] = "設定聊天視窗之間分隔線的位置"
 L["Set the opacity of the window background"] = "設定視窗背景不透明度"
 L["Right Window Texts"] = "右側視窗文字"
 
@@ -779,5 +783,6 @@ L["Display the timer on unit frame auras"] = "在單位框架光環上顯示計�
 
 -- Update
 L["You can get an updated version of HydraUI at https://www.curseforge.com/wow/addons/hydraui"] = "可於 https://www.curseforge.com/wow/addons/hydraui 取得 HydraUI 最新版本"
+L["Update available"] = "有可用的更新"
 L["New Version!"] = "新版本！"
 L["Update to version |cFF%s%s|r"] = "更新至版本 |cFF%s%s|r"

--- a/HydraUI/Elements/Reputation.lua
+++ b/HydraUI/Elements/Reputation.lua
@@ -394,7 +394,7 @@ HydraUI:GetModule("GUI"):AddWidgets(Language["General"], Language["Reputation"],
 	right:CreateDropdown("reputation-progress-visibility", Settings["reputation-progress-visibility"], {[Language["Always Show"]] = "ALWAYS", [Language["Mouseover"]] = "MOUSEOVER"}, Language["Progress Text"], Language["Set when to display the progress information"], UpdateProgressVisibility)
 	right:CreateDropdown("reputation-percent-visibility", Settings["reputation-percent-visibility"], {[Language["Always Show"]] = "ALWAYS", [Language["Mouseover"]] = "MOUSEOVER"}, Language["Percent Text"], Language["Set when to display the percent information"], UpdatePercentVisibility)
 
-	left:CreateHeader("Mouseover")
+left:CreateHeader(Language["Mouseover"])
 	left:CreateSwitch("reputation-mouseover", Settings["reputation-mouseover"], Language["Display On Mouseover"], Language["Only display the reputation bar while mousing over it"], UpdateMouseover)
 	left:CreateSlider("reputation-mouseover-opacity", Settings["reputation-mouseover-opacity"], 0, 100, 5, Language["Mouseover Opacity"], Language["Set the opacity of the reputation bar while not mousing over it"], UpdateMouseoverOpacity, nil, "%")
 end)


### PR DESCRIPTION
## Summary
- localize the right chat window divider and header strings and add the missing tooltip text
- localize the credit thank-you message and use the translated mouseover headers
- add translations for the new chat labels across every supported locale

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d74298a298832fa0005020624d6e66