### PR TITLE
Localize help command strings and profile errors

### DIFF
--- a/HydraUI/Elements/Commands.lua
+++ b/HydraUI/Elements/Commands.lua
@@ -50,11 +50,11 @@ end
 Commands["help"] = function()
 	print(format(Language["|cFF%sHydraUI|r Commands"], Settings["ui-widget-color"]))
 	print(" ")
-	print(format("|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window", Settings["ui-widget-color"]))
-	print(format("|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen", Settings["ui-widget-color"]))
-	print(format("|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations", Settings["ui-widget-color"]))
-	print(format("|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding", Settings["ui-widget-color"]))
-	print(format("|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings", Settings["ui-widget-color"]))
+	print(format(Language["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"], Settings["ui-widget-color"]))
+	print(format(Language["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"], Settings["ui-widget-color"]))
+	print(format(Language["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"], Settings["ui-widget-color"]))
+	print(format(Language["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"], Settings["ui-widget-color"]))
+	print(format(Language["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"], Settings["ui-widget-color"]))
 end
 
 local RunCommand = function(arg)

--- a/HydraUI/Elements/Languages/deDE.lua
+++ b/HydraUI/Elements/Languages/deDE.lua
@@ -322,11 +322,11 @@ L["Uninterruptible"] = "Nicht unterbrechbar"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "|cFF%sHydraUI|r-Befehle"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Öffnet das Einstellungsfenster"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Verschiebt UI-Elemente auf dem Bildschirm"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Setzt alle Anker auf ihre Standardpositionen zurück"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Aktiviert das Belegen per Mausüberfahrt"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Setzt alle UI-Informationen und Einstellungen zurück"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Schaltet das Einstellungsfenster um"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Verschiebt UI-Elemente auf dem Bildschirm"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Setzt alle Anker auf ihre Standardpositionen zurück"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Schaltet das Belegen per Mausüberfahrt um"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Setzt alle UI-Informationen und Einstellungen zurück"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r ist bereit!"
@@ -634,6 +634,9 @@ L['Profile "%s" has been copied from "%s".'] = 'Profil "%s" wurde von "%s" kopie
 L['Are you sure you would like to change to the current profile to "%s"?'] = 'Bist du sicher, dass du zum aktuellen Profil "%s" wechseln möchtest?'
 L["Are you sure you would like to copy %s to %s?"] = "Bist du sicher, dass du %s nach %s kopieren möchtest?"
 L["All"] = "Alle"
+L["Failure decoding"] = "Fehler beim Dekodieren"
+L["Failure decompressing"] = "Fehler beim Dekomprimieren"
+L["Failure deserializing"] = "Fehler beim Deserialisieren"
 
 -- Reputation
 L["Reputation"] = "Ruf"

--- a/HydraUI/Elements/Languages/esES.lua
+++ b/HydraUI/Elements/Languages/esES.lua
@@ -319,11 +319,11 @@ L["Uninterruptible"] = "Ininterrumpible"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "Comandos de |cFF%sHydraUI|r"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Alterna la ventana de configuración"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Arrastra elementos de la IU por la pantalla"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Recoloca todos los marcos móviles en su posición predeterminada"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Alterna la asignación de teclas al pasar el ratón"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Restablece toda la información y ajustes guardados de la IU"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Alterna la ventana de configuración"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Arrastra elementos de la IU por la pantalla"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Recoloca todos los marcos móviles en su posición predeterminada"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Alterna la asignación de teclas al pasar el ratón"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Restablece toda la información y ajustes guardados de la IU"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "¡|cff%s%s|r está listo!"
@@ -623,6 +623,9 @@ L['Profile "%s" has been copied from "%s".'] = 'El perfil "%s" se ha copiado de 
 L['Are you sure you would like to change to the current profile to "%s"?'] = '¿Seguro que quieres cambiar el perfil actual a "%s"?'
 L["Are you sure you would like to copy %s to %s?"] = "¿Seguro que quieres copiar %s en %s?"
 L["All"] = "Todo"
+L["Failure decoding"] = "Error al decodificar"
+L["Failure decompressing"] = "Error al descomprimir"
+L["Failure deserializing"] = "Error al deserializar"
 
 -- Reputation
 L["Reputation"] = "Reputación"

--- a/HydraUI/Elements/Languages/esMX.lua
+++ b/HydraUI/Elements/Languages/esMX.lua
@@ -319,11 +319,11 @@ L["Uninterruptible"] = "Ininterrumpible"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "Comandos de |cFF%sHydraUI|r"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Alterna la ventana de configuración"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Arrastra elementos de la IU por la pantalla"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Recoloca todos los marcos móviles en su posición predeterminada"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Alterna la asignación de teclas al pasar el ratón"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Restablece toda la información y ajustes guardados de la IU"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Alterna la ventana de configuración"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Arrastra elementos de la IU por la pantalla"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Recoloca todos los marcos móviles en su posición predeterminada"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Alterna la asignación de teclas al pasar el ratón"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Restablece toda la información y ajustes guardados de la IU"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "¡|cff%s%s|r está listo!"
@@ -623,6 +623,9 @@ L['Profile "%s" has been copied from "%s".'] = 'El perfil "%s" se ha copiado de 
 L['Are you sure you would like to change to the current profile to "%s"?'] = '¿Seguro que quieres cambiar el perfil actual a "%s"?'
 L["Are you sure you would like to copy %s to %s?"] = "¿Seguro que quieres copiar %s en %s?"
 L["All"] = "Todo"
+L["Failure decoding"] = "Error al decodificar"
+L["Failure decompressing"] = "Error al descomprimir"
+L["Failure deserializing"] = "Error al deserializar"
 
 -- Reputation
 L["Reputation"] = "Reputación"

--- a/HydraUI/Elements/Languages/frFR.lua
+++ b/HydraUI/Elements/Languages/frFR.lua
@@ -1623,6 +1623,10 @@ L['Are you sure you would like to change to the current profile to "%s"?'] = 'Vo
 L["Are you sure you would like to copy %s to %s?"] = "Voulez-vous vraiment copier %s vers %s ?"
 L["All"] = "Tous"
 
+L["Failure decoding"] = "Échec du décodage"
+L["Failure decompressing"] = "Échec de la décompression"
+L["Failure deserializing"] = "Échec de la désérialisation"
+
 -- Reputation Options
 L["Reputation"] = "Réputation"
 L["Enable Reputation Module"] = "Activer le module de réputation"
@@ -2269,4 +2273,9 @@ L["Width"] = "Width"
 L["Your equipped items have been repaired for %s using guild funds"] = "Your equipped items have been repaired for %s using guild funds"
 L["Zone Colors"] = "Zone Colors"
 L["|cFF%sHydraUI|r Commands"] = "|cFF%sHydraUI|r Commands"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Affiche ou masque la fenêtre des options"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Déplace les éléments de l'interface sur l'écran"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Replace tous les cadres mobiles à leur position par défaut"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Active/désactive l'association de touches au survol"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Réinitialise toutes les informations et options d'interface enregistrées"
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r is ready!"

--- a/HydraUI/Elements/Languages/itIT.lua
+++ b/HydraUI/Elements/Languages/itIT.lua
@@ -320,11 +320,11 @@ L["Uninterruptible"] = "Non interrompibile"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "Comandi di |cFF%sHydraUI|r"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Attiva/disattiva la finestra delle impostazioni"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Trascina gli elementi dell'UI sullo schermo"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Riposiziona tutti i riquadri mobili nelle posizioni predefinite"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Attiva la configurazione dei tasti al passaggio del mouse"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reimposta tutte le informazioni e impostazioni dell'UI memorizzate"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Attiva/disattiva la finestra delle impostazioni"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Trascina gli elementi dell'UI sullo schermo"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Riposiziona tutti i riquadri mobili nelle posizioni predefinite"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Attiva/disattiva la configurazione dei tasti al passaggio del mouse"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reimposta tutte le informazioni e impostazioni dell'UI memorizzate"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r è pronto!"
@@ -632,6 +632,9 @@ L['Profile "%s" has been copied from "%s".'] = 'Il profilo "%s" è stato copiato
 L['Are you sure you would like to change to the current profile to "%s"?'] = 'Sei sicuro di voler cambiare il profilo attuale in "%s"?'
 L["Are you sure you would like to copy %s to %s?"] = "Sei sicuro di voler copiare %s in %s?"
 L["All"] = "Tutti"
+L["Failure decoding"] = "Errore durante la decodifica"
+L["Failure decompressing"] = "Errore durante la decompressione"
+L["Failure deserializing"] = "Errore durante la deserializzazione"
 
 -- Reputation
 L["Reputation"] = "Reputazione"

--- a/HydraUI/Elements/Languages/koKR.lua
+++ b/HydraUI/Elements/Languages/koKR.lua
@@ -322,11 +322,11 @@ L["Uninterruptible"] = "차단 불가"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "|cFF%sHydraUI|r 명령어"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - 설정 창을 전환합니다"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - UI 요소를 화면에서 드래그합니다"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - 모든 이동 요소를 기본 위치로 되돌립니다"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - 마우스오버 단축키 설정을 전환합니다"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - 저장된 UI 정보와 설정을 모두 초기화합니다"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - 설정 창을 전환합니다"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - UI 요소를 화면에서 드래그합니다"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - 모든 이동 요소를 기본 위치로 되돌립니다"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - 마우스오버 단축키 설정을 전환합니다"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - 저장된 UI 정보와 설정을 모두 초기화합니다"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r 사용 준비 완료!"
@@ -634,6 +634,9 @@ L['Profile "%s" has been copied from "%s".'] = '프로필 "%s"이(가) "%s"에�
 L['Are you sure you would like to change to the current profile to "%s"?'] = '현재 프로필을 "%s"(으)로 변경하시겠습니까?'
 L["Are you sure you would like to copy %s to %s?"] = "%s의 설정을 %s(으)로 복사하시겠습니까?"
 L["All"] = "전체"
+L["Failure decoding"] = "디코딩 실패"
+L["Failure decompressing"] = "압축 해제 실패"
+L["Failure deserializing"] = "역직렬화 실패"
 
 -- Reputation
 L["Reputation"] = "평판"

--- a/HydraUI/Elements/Languages/ptBR.lua
+++ b/HydraUI/Elements/Languages/ptBR.lua
@@ -322,11 +322,11 @@ L["Uninterruptible"] = "Ininterrupto"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "Comandos do |cFF%sHydraUI|r"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Alterna a janela de configurações"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Arrasta elementos da interface pela tela"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposiciona todos os quadros móveis para as posições padrão"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Alterna a configuração de atalhos ao passar o mouse"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Redefine todas as informações e configurações salvas da interface"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Alterna a janela de configurações"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Arrasta elementos da interface pela tela"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposiciona todos os quadros móveis para as posições padrão"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Alterna a configuração de atalhos ao passar o mouse"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Redefine todas as informações e configurações salvas da interface"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r está pronto!"
@@ -634,6 +634,9 @@ L['Profile "%s" has been copied from "%s".'] = 'O perfil "%s" foi copiado de "%s
 L['Are you sure you would like to change to the current profile to "%s"?'] = 'Tem certeza de que deseja alterar o perfil atual para "%s"?'
 L["Are you sure you would like to copy %s to %s?"] = "Tem certeza de que deseja copiar %s para %s?"
 L["All"] = "Tudo"
+L["Failure decoding"] = "Falha ao decodificar"
+L["Failure decompressing"] = "Falha ao descompactar"
+L["Failure deserializing"] = "Falha ao desserializar"
 
 -- Reputation
 L["Reputation"] = "Reputação"

--- a/HydraUI/Elements/Languages/ruRU.lua
+++ b/HydraUI/Elements/Languages/ruRU.lua
@@ -321,11 +321,11 @@ L["Uninterruptible"] = "Непрерываемо"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "Команды |cFF%sHydraUI|r"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Открыть окно настроек"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Перемещать элементы интерфейса по экрану"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Сбросить все перемещения в позиции по умолчанию"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Настроить назначение клавиш при наведении"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Сбросить все сохранённые данные интерфейса"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - Открыть или закрыть окно настроек"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - Перемещать элементы интерфейса по экрану"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Вернуть все фиксаторы в позиции по умолчанию"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Включить или отключить назначение клавиш при наведении"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Сбросить все сохранённые данные интерфейса"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r готов(о)!"
@@ -633,6 +633,9 @@ L['Profile "%s" has been copied from "%s".'] = 'Профиль "%s" скопир
 L['Are you sure you would like to change to the current profile to "%s"?'] = 'Вы действительно хотите сменить текущий профиль на "%s"?'
 L["Are you sure you would like to copy %s to %s?"] = "Скопировать %s в %s?"
 L["All"] = "Все"
+L["Failure decoding"] = "Не удалось декодировать"
+L["Failure decompressing"] = "Не удалось распаковать"
+L["Failure deserializing"] = "Не удалось десериализовать"
 
 -- Reputation
 L["Reputation"] = "Репутация"

--- a/HydraUI/Elements/Languages/zhCN.lua
+++ b/HydraUI/Elements/Languages/zhCN.lua
@@ -322,11 +322,11 @@ L["Uninterruptible"] = "不可打断"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "|cFF%sHydraUI|r 指令"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - 切换设置窗口"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - 在画面上拖动界面组件"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - 将所有移动框架重设至默认位置"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - 切换鼠标指向按键绑定"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - 重设所有保存的界面信息与设置"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - 切换设置窗口"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - 在画面上拖动界面组件"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - 将所有移动框架重设至默认位置"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - 切换鼠标指向按键绑定"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - 重设所有保存的界面信息与设置"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r 已就绪！"
@@ -634,6 +634,9 @@ L['Profile "%s" has been copied from "%s".'] = '设置档 "%s" 已自 "%s" 复�
 L['Are you sure you would like to change to the current profile to "%s"?'] = '确定要将目前设置档切换为 "%s" 吗？'
 L["Are you sure you would like to copy %s to %s?"] = "确定要将 %s 复制到 %s 吗？"
 L["All"] = "全部"
+L["Failure decoding"] = "解码失败"
+L["Failure decompressing"] = "解压失败"
+L["Failure deserializing"] = "反序列化失败"
 
 -- Reputation
 L["Reputation"] = "声望"

--- a/HydraUI/Elements/Languages/zhTW.lua
+++ b/HydraUI/Elements/Languages/zhTW.lua
@@ -322,11 +322,11 @@ L["Uninterruptible"] = "不可打斷"
 
 -- Commands
 L["|cFF%sHydraUI|r Commands"] = "|cFF%sHydraUI|r 指令"
-L["|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - Toggle the settings window"] = "|Hcommand:/HydraUI|h|cFF%s/HydraUI|r|h - 切換設定視窗"
-L["|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - Drag UI elements around the screen"] = "|Hcommand:/HydraUI move|h|cFF%s/HydraUI move|r|h - 在畫面上拖曳介面元件"
-L["|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/HydraUI movereset|h|cFF%s/HydraUI movereset|r|h - 將所有移動框架重設至預設位置"
-L["|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/HydraUI keybind|h|cFF%s/HydraUI keybind|r|h - 切換滑鼠指向按鍵綁定"
-L["|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/HydraUI reset|h|cFF%s/HydraUI reset|r|h - 重設所有儲存的介面資訊與設定"
+L["|Hcommand:/hui|h|cFF%s/hui|r|h - Toggle the settings window"] = "|Hcommand:/hui|h|cFF%s/hui|r|h - 切換設定視窗"
+L["|Hcommand:/hui move|h|cFF%s/hui move|r|h - Drag UI elements around the screen"] = "|Hcommand:/hui move|h|cFF%s/hui move|r|h - 在畫面上拖曳介面元件"
+L["|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - Reposition all movers to their default locations"] = "|Hcommand:/hui movereset|h|cFF%s/hui movereset|r|h - 將所有移動框架重設至預設位置"
+L["|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - Toggle mouseover keybinding"] = "|Hcommand:/hui keybind|h|cFF%s/hui keybind|r|h - 切換滑鼠指向按鍵綁定"
+L["|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - Reset all stored UI information and settings"] = "|Hcommand:/hui reset|h|cFF%s/hui reset|r|h - 重設所有儲存的介面資訊與設定"
 
 -- Cooldowns
 L["|cff%s%s|r is ready!"] = "|cff%s%s|r 已就緒！"
@@ -634,6 +634,9 @@ L['Profile "%s" has been copied from "%s".'] = '設定檔 "%s" 已自 "%s" 複�
 L['Are you sure you would like to change to the current profile to "%s"?'] = '確定要將目前設定檔切換為 "%s" 嗎？'
 L["Are you sure you would like to copy %s to %s?"] = "確定要將 %s 複製到 %s 嗎？"
 L["All"] = "全部"
+L["Failure decoding"] = "解碼失敗"
+L["Failure decompressing"] = "解壓縮失敗"
+L["Failure deserializing"] = "反序列化失敗"
 
 -- Reputation
 L["Reputation"] = "聲望"

--- a/HydraUI/Elements/Profiles.lua
+++ b/HydraUI/Elements/Profiles.lua
@@ -609,19 +609,19 @@ function HydraUI:DecodeProfile(encoded)
 	local Decoded = LibDeflate:DecodeForPrint(encoded)
 
 	if (not Decoded) then
-		return self:print("Failure decoding")
+		return self:print(Language["Failure decoding"])
 	end
 
 	local Decompressed = LibDeflate:DecompressDeflate(Decoded)
 
 	if (not Decompressed) then
-		return self:print("Failure decompressing")
+		return self:print(Language["Failure decompressing"])
 	end
 
 	local Success, Deserialized = AceSerializer:Deserialize(Decompressed)
 
 	if (not Success) then
-		return self:print("Failure deserializing")
+		return self:print(Language["Failure deserializing"])
 	end
 
 	-- Check for migrated values


### PR DESCRIPTION
## Summary
- route the help command output through the localization table
- add localized profile import error messages to the shared language keys
- update each locale file with the new slash command text and error strings

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d74afeefd0832fb7c0fb3fdfe65fc1