### PR TITLE
Fix toggle switch thumb animation

### DIFF
--- a/HydraUI/Elements/Libraries/LibMotion.lua
+++ b/HydraUI/Elements/Libraries/LibMotion.lua
@@ -1069,7 +1069,10 @@ Update.move = function(self, elapsed)
             self.YOffset = self.StartY + self.YChange * EasingValue
         end
 
-        self.Parent:SetPoint(self.A1, self.P, self.A2, (self.EndX ~= 0 and self.XOffset or self.StartX), (self.EndY ~= 0 and self.YOffset or self.StartY))
+        local HasXChange = (self.XChange ~= 0)
+        local HasYChange = (self.YChange ~= 0)
+
+        self.Parent:SetPoint(self.A1, self.P, self.A2, (HasXChange and self.XOffset or self.StartX), (HasYChange and self.YOffset or self.StartY))
     end
 end
 


### PR DESCRIPTION
## Summary
- update the LibMotion move animation to use the calculated change when positioning animated frames
- allow toggle switch thumbs to animate properly when moving back to the zero offset

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d779edd564832fa4d55558f1578dd2